### PR TITLE
Use meta.Name

### DIFF
--- a/handlers/upload_handler.go
+++ b/handlers/upload_handler.go
@@ -198,7 +198,7 @@ func rootCIDMatches(node *core.IpfsNode, rootCID string, filesMeta []FileMetadat
 
 		fileHeader := files[meta.Cid][0]
 		dir := filepath.Join(rootDir, filepath.Dir(meta.Name))
-		filePath := filepath.Join(dir, fileHeader.Filename)
+		filePath := filepath.Join(dir, filepath.Base(meta.Name))
 
 		err := os.MkdirAll(dir, os.ModePerm)
 		if err != nil {


### PR DESCRIPTION
As it was, if the fileHeader.Filename contains a path to the file for example:

folder/data.txt

Appending the calculated dir variable to fileHeader.Filename could result in a wrong path with part of the folder structure duplicated.

for example:
// rootDir = a/path
//mata.Name = folder/data.xt
// fileHeader.Filename = folder/data.xt
dir := filepath.Join(rootDir, filepath.Dir(meta.Name)) // dir = a/path/**folder**
filePath := filepath.Join(dir, fileHeader.Filename) // filePath =  a/path/**folder/folder/data.txt**

instead, if we use 

filePath := filepath.Join(dir, filepath.Base(meta.Name)) // filePath =  a/path/**folder/data.txt**