### PR TITLE
fix: allow gltf model content type

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,4 +30,5 @@ allowedContentTypes:    # Set ALLOWED_TYPES (a comma separated string whit all t
   - 'application/javascript'
   - 'application/octet-stream'
   - 'audio.*'
+  - 'model.*'
   - 'application/xml'

--- a/data/authorization.go
+++ b/data/authorization.go
@@ -108,10 +108,13 @@ func getParcels(parcelsList []string, dcl Decentraland) ([]*Parcel, error) {
 }
 
 func canModify(pubkey string, parcel *Parcel, dcl Decentraland) (bool, error) {
+	var check = strings.ToLower(pubkey)
+
 	log.Debugf("Verifying Address [%s] permissions over Parcel[%d,%d]", pubkey, parcel.X, parcel.Y)
-	if pubkey == parcel.Owner {
+
+	if check == parcel.Owner {
 		return true, nil
-	} else if pubkey == parcel.UpdateOperator {
+	} else if check == parcel.UpdateOperator {
 		return true, nil
 	} else if parcel.EstateID != "" {
 		estateID, err := strconv.Atoi(parcel.EstateID)
@@ -126,9 +129,9 @@ func canModify(pubkey string, parcel *Parcel, dcl Decentraland) (bool, error) {
 			return false, err
 		}
 
-		if pubkey == estate.Owner {
+		if check == estate.Owner {
 			return true, nil
-		} else if pubkey == estate.UpdateOperator {
+		} else if check == estate.UpdateOperator {
 			return true, nil
 		}
 	}

--- a/handlers/upload_service.go
+++ b/handlers/upload_service.go
@@ -229,7 +229,7 @@ func validateKeyAccess(a data.Authorization, pKey string, parcels []string) erro
 		log.Infof("Error validating PublicKey[%s]", pKey)
 		return WrapInBadRequestError(err)
 	} else if !canModify {
-		log.Infof("PublicKey[%s] is not allow to modify parcels", pKey)
+		log.Infof("PublicKey[%s] is not allowed to modify parcels", pKey)
 		return StatusError{http.StatusUnauthorized, errors.New("address is not authorized to modify given parcels")}
 	}
 	return nil


### PR DESCRIPTION
This commit fixes a typo, allows gltf content type as reported by linux, and lower-cases the address provided by the user (it was failing due to the ethereum checksum that uses the lower and upper cases on addresses to detect mistakes on typing the address)